### PR TITLE
Fix NoneType while setting up background API task

### DIFF
--- a/apis/utils/call_worker.py
+++ b/apis/utils/call_worker.py
@@ -72,7 +72,7 @@ async def execute_in_background(task: AsyncTask, raw_req: CommonRequest, in_queu
                 )
                 CurrentTask.task = task
             flag, product = task.yields.pop(0)
-            if flag == 'preview':
+            if flag == 'preview' and CurrentTask.ct != None:
                 if len(task.yields) > 0:
                     if task.yields[0][0] == 'preview':
                         continue


### PR DESCRIPTION
There was no checks to ensure that the background task had been fully initialised before attempting to update the progress indicator. - Added check for this before processing